### PR TITLE
Remove readahead variable as there is no readahead data now

### DIFF
--- a/bcache.py
+++ b/bcache.py
@@ -141,7 +141,7 @@ def read_callback():
             for t in ['five_minute', 'hour', 'day', 'total']:
                 cache_ratio = get_cache_ratio(uuid, t)
                 dispatch(device, 'cache_ratio', t, cache_ratio)
-            for c in ['bypass_hits', 'bypass_misses', 'hits', 'miss_collisions', 'misses', 'readaheads']:
+            for c in ['bypass_hits', 'bypass_misses', 'hits', 'miss_collisions', 'misses']:
                 cache_result = get_cache_result(uuid, c)
                 dispatch(device, 'requests', c, cache_result)
             bypassed = get_bypassed(uuid)


### PR DESCRIPTION
According to https://lkml.org/lkml/2021/6/14/718 readahead feature has been removed from bcache as there is fs readahead

Duplicate this comment for the sake of order :)